### PR TITLE
Use error objects

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,15 +18,20 @@ function setup_response_handler(res, callback) {
         });
     res.on('end',
         function() {
-            var err = 201 >= res.statusCode ? 0 : res.statusCode;
-            try {
-                response = JSON.parse(response);
-            }
-            catch(e) {
-                callback({ error : { message : 'Invalid JSON from uploadcare.com' } });
-                return;
-            }
-            callback(err, response);
+          var err;
+
+          if (res.statusCode > 201) {
+              err = new Error('Unexpected status ' + res.statusCode + ' from uploadcare.com');
+          }
+
+          try {
+              response = JSON.parse(response);
+          }
+          catch(e) {
+              return callback(new Error('Invalid JSON from uploadcare.com'));
+          }
+
+          callback(err, response);
         });
 }
 
@@ -148,7 +153,7 @@ module.exports = function (public_key, private_key, options) {
                                 return callback(err)
                             }
                             if(file.status==='error'){
-                                return callback(file.error,file)                                
+                                return callback(file.error,file)
                             }
                             if(file.status==='success'){
                                 return callback(err,file)


### PR DESCRIPTION
This PR ensures that uploadcare-node passes error instances to callbacks when bad things happen, instead of numbers or plain objects.

My use case:

In Hapi, you call `reply()` and pass it your response object or an Error instance. If you give it an error, it'll automatically respond to the client with a HTTP 500 along with the error message. For any other type it'll `JSON.stringify` it and respond with a HTTP 200.

My problem was that uploadcare was returning a `401` as the error object for the callback, and I was giving that directly to hapi, e.g.:

```js
uploadcare.store(xxx, function (err) {
  if (err) return reply(err)
})
```

It meant that Hapi was responding with a HTTP 200, and a 401 __number__ as the JSON body! This PR fixes this issue.
