### PR TITLE
Add `store` option as `auto` for uploads

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -120,6 +120,7 @@ module.exports = function (public_key, private_key, options) {
                 var form = new FormData();
                 form.append( 'UPLOADCARE_PUB_KEY', public_key );
                 form.append( 'file', fileStream );
+                form.append( 'store', 'auto' );
                 post('/base/', {
                     data:   form,
                     ssl:    true,


### PR DESCRIPTION
Calling `fromUrl` will set the `store` option to `auto`, but calling `upload` will not. This means that files being uploaded with this package will be removed automatically unless you also call `store` explicitly. I suggest setting the `store` option to `auto` when calling `upload` for consistency and ease of use.