### PR TITLE
Added option to wait until file is ready for download

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -209,7 +209,13 @@ module.exports = function(public_key, private_key, options) {
                                 return callback(file.error,file)
                             }
                             if(file.status==='success'){
-                                return callback(err,file)
+                                if(options.waitUntilReady){
+                                    if(file.is_ready){
+                                        return callback(err,file)
+                                    }
+                                }else{
+                                    return callback(err,file)
+                                }
                             }
                             setTimeout(tick, 100);
                         })


### PR DESCRIPTION
The `/status` endpoint returns success when the image is done uploading but that doesn't necessarily mean it's ready to be downloaded/accessed. The `is_ready` flag means it's ready to download. Added an option that if true tells the `fromUrl` function to wait until the image is ready before calling the callback function.

See the example response here: https://uploadcare.com/documentation/upload/#from-url
```
{
  "status": "success",
  "is_stored": true,
  "done": 145212,
  "file_id": "575ed4e8-f4e8-4c14-a58b-1527b6d9ee46",
  "total": 145212,
  "size": 145212,
  "uuid": "575ed4e8-f4e8-4c14-a58b-1527b6d9ee46",
  "is_image": true,
  "filename": "EU_4.jpg",
  "is_ready": true, <---- means it's ready to download
  "original_filename": "EU_4.jpg",
  "mime_type": "image/jpeg",
  "image_info": {
    "orientation": null,
    "format": "JPEG",
    "height": 640,
    "width": 960,
    "geo_location": null,
    "datetime_original": null
  }
}
```
