### PR TITLE
Use https by default

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -72,6 +72,7 @@ module.exports = function(public_key, private_key, options) {
     function _request(method, path, options, callback){
         var request_data = JSON.stringify(options.data);
         if(!options.data) { request_data = ''; }
+        var ssl = options.ssl !== false;
 
         //Prepare headers
         var content_type = 'application/json',
@@ -82,7 +83,7 @@ module.exports = function(public_key, private_key, options) {
             sign = crypto.createHmac('sha1', private_key).update(sign_string).digest('hex'),
             request_options = {
                 host: 'api.uploadcare.com',
-                port: (options.ssl ? 443 : 80),
+                port: (ssl ? 443 : 80),
                 path: path,
                 method: method,
                 headers: {
@@ -93,7 +94,7 @@ module.exports = function(public_key, private_key, options) {
                 }
             };
 
-        var req = (options.ssl ? https.request(request_options) : http.request(request_options));
+        var req = (ssl ? https.request(request_options) : http.request(request_options));
 
         req.on('response',function(res){
             setup_response_handler(res, callback);


### PR DESCRIPTION
Uploadcare is effectively removing support for using HTTP.
https://uploadcare.com/docs/changelog/#upcoming-301-redirect-to-api-endpoints--may-1-2022

HTTPS really should be the default anyway, I've tested this change with the usage,js file, seems to work.