### PR TITLE
Bumping version to 0.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uploadcare",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Library for uploadcare.com.",
   "keywords": [
     "upload",


### PR DESCRIPTION
We want to publish updated readme with deprecation message to npm, see https://github.com/uploadcare/uploadcare-node/pull/26